### PR TITLE
Reverted publish logic

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -17,7 +17,7 @@ import logging
 
 # Nuke versions compatibility constants
 VERSION_OLDEST_COMPATIBLE = (14, 0, 1)
-VERSION_OLDEST_SUPPORTED = (15, 0, 8)
+VERSION_OLDEST_SUPPORTED = (15, 0, 1)
 VERSION_NEWEST_SUPPORTED = (17, 0, 99)
 # Caution: make sure compatibility_dialog_min_version default value in info.yml
 # is equal to VERSION_NEWEST_SUPPORTED

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -93,7 +93,9 @@ class NukeSessionCollector(HookBaseClass):
         else:
             # running nuke. ensure additional collected outputs are parented
             # under the session
-            project_item = self.collect_current_nuke_session(settings, parent_item)
+            project_item = self.collect_current_nuke_session(
+                settings, parent_item
+            )
 
         # run node collection if not in hiero
         if hasattr(engine, "hiero_enabled") and not engine.hiero_enabled:
@@ -127,7 +129,9 @@ class NukeSessionCollector(HookBaseClass):
         )
 
         # get the icon path to display for this item
-        icon_path = os.path.join(self.disk_location, os.pardir, "icons", "nuke.png")
+        icon_path = os.path.join(
+            self.disk_location, os.pardir, "icons", "nuke.png"
+        )
         session_item.set_icon_from_path(icon_path)
 
         # if a work template is defined, add it to the item properties so
@@ -174,7 +178,7 @@ class NukeSessionCollector(HookBaseClass):
         else:
             active_project = None
 
-        # attempt to retrive a configured work template. we can attach
+        # attempt to retrieve a configured work template. we can attach
         # it to the collected project items
         work_template_setting = settings.get("Work Template")
         work_template = None
@@ -194,7 +198,9 @@ class NukeSessionCollector(HookBaseClass):
             if not active_project:
                 return
             project_item = parent_item.create_item(
-                "nukestudio.project", "NukeStudio Project", active_project.name()
+                "nukestudio.project",
+                "NukeStudio Project",
+                active_project.name(),
             )
             self.logger.info(
                 "Collected Nuke Studio project: %s" % (active_project.name(),)
@@ -202,7 +208,9 @@ class NukeSessionCollector(HookBaseClass):
             project_item.set_icon_from_path(icon_path)
             project_item.properties["project"] = active_project
             project_item.properties["work_template"] = work_template
-            self.logger.debug("Work template defined for NukeStudio collection.")
+            self.logger.debug(
+                "Work template defined for NukeStudio collection."
+            )
             return
         # FIXME: end temporary workaround
 
@@ -218,7 +226,9 @@ class NukeSessionCollector(HookBaseClass):
             # plugins know which open project to associate with this item
             project_item.properties["project"] = project
 
-            self.logger.info("Collected Nuke Studio project: %s" % (project.name(),))
+            self.logger.info(
+                "Collected Nuke Studio project: %s" % (project.name(),)
+            )
 
             # enable the active project and expand it. other projects are
             # collapsed and disabled.
@@ -238,7 +248,9 @@ class NukeSessionCollector(HookBaseClass):
             # execution time.
             if work_template:
                 project_item.properties["work_template"] = work_template
-                self.logger.debug("Work template defined for NukeStudio collection.")
+                self.logger.debug(
+                    "Work template defined for NukeStudio collection."
+                )
 
     def collect_node_outputs(self, parent_item):
         """
@@ -252,7 +264,9 @@ class NukeSessionCollector(HookBaseClass):
         for node_type in _NUKE_OUTPUTS:
 
             # get all the instances of the node type
-            all_nodes_of_type = [n for n in nuke.allNodes() if n.Class() == node_type]
+            all_nodes_of_type = [
+                n for n in nuke.allNodes() if n.Class() == node_type
+            ]
 
             # iterate over each instance
             for node in all_nodes_of_type:
@@ -267,7 +281,9 @@ class NukeSessionCollector(HookBaseClass):
                     # no file or file does not exist, nothing to do
                     continue
 
-                self.logger.info("Processing %s node: %s" % (node_type, node.name()))
+                self.logger.info(
+                    "Processing %s node: %s" % (node_type, node.name())
+                )
 
                 # file exists, let the basic collector handle it
                 item = super()._collect_file(
@@ -300,94 +316,98 @@ class NukeSessionCollector(HookBaseClass):
         first_frame = int(nuke.root()["first_frame"].value())
         last_frame = int(nuke.root()["last_frame"].value())
 
-        for node in sg_writenode_app.get_write_nodes():
+        for node in sg_writenode_app.get_all_write_nodes():
+            node = nuke.toNode(node)
+            render_path = node["file"].value()
 
-            # see if any frames have been rendered for this write node
-            rendered_files = sg_writenode_app.get_node_render_files(node)
-            if not rendered_files:
-                continue
+            if render_path:
+                is_published = sg_writenode_app.get_published_status(node)
+                if not is_published:
+                    item_info = super(
+                        NukeSessionCollector, self
+                    )._get_item_info(render_path)
 
-            # some files rendered, use first frame to get some publish item info
-            path = rendered_files[0]
-            item_info = super()._get_item_info(path)
+                    item_type = "%s.sequence" % (item_info["item_type"],)
+                    type_display = "%s Sequence" % (item_info["type_display"],)
 
-            # item_info will be for the single file. we'll update the type and
-            # display to represent a sequence. This is the same pattern used by
-            # the base collector for image sequences. We're not using the base
-            # collector to create the publish item though since we already have
-            # the sequence path, template knowledge provided by the
-            # tk-nuke-writenode app. The base collector makes some "zero config"
-            # assupmtions about the path that we don't need to make here.
-            item_type = "%s.sequence" % (item_info["item_type"],)
-            type_display = "%s Sequence" % (item_info["type_display"],)
+                    # construct publish name:
+                    render_template = (
+                        sg_writenode_app.get_node_render_template(node)
+                    )
+                    render_path_fields = render_template.get_fields(
+                        render_path
+                    )
 
-            # we'll publish the path with the frame/eye spec (%V, %04d)
-            publish_path = sg_writenode_app.get_node_render_path(node)
+                    output_name = render_path_fields.get("output")
 
-            # construct publish name:
-            render_template = sg_writenode_app.get_node_render_template(node)
-            render_path_fields = render_template.get_fields(publish_path)
+                    render_directory = os.path.dirname(render_path)
+                    image_sequences = publisher.util.get_frame_sequences(
+                        render_directory
+                    )
+                    for image_sequence in image_sequences:
+                        if (
+                            image_sequence[0].replace(os.sep, "/")
+                            == render_path
+                        ):
 
-            rp_name = render_path_fields.get("name")
-            rp_channel = render_path_fields.get("channel")
-            if not rp_name and not rp_channel:
-                publish_name = "Publish"
-            elif not rp_name:
-                publish_name = "Channel %s" % rp_channel
-            elif not rp_channel:
-                publish_name = rp_name
-            else:
-                publish_name = "%s, Channel %s" % (rp_name, rp_channel)
+                            sequence_files = []
+                            for file in image_sequence[1]:
+                                file = file.replace(os.sep, "/")
+                                sequence_files.append(file)
 
-            # get the version number from the render path
-            version_number = render_path_fields.get("version")
+                            # get the version number from the render path
+                            version_number = render_path_fields.get("version")
 
-            # use the path basename and nuke writenode name for display
-            _, filename = os.path.split(publish_path)
-            display_name = "%s (%s)" % (publish_name, node.name())
+                            # use the path basename and nuke writenode name for display
+                            display_name = "%s (%s)" % (
+                                output_name,
+                                node.name(),
+                            )
 
-            # create and populate the item
-            item = parent_item.create_item(item_type, type_display, display_name)
-            item.set_icon_from_path(item_info["icon_path"])
+                            # Set publish name
+                            publish_name = publisher.util.get_publish_name(
+                                render_path
+                            )
 
-            # if the supplied path is an image, use the path as # the thumbnail.
-            item.set_thumbnail_from_path(path)
+                            # create and populate the item
+                            item = parent_item.create_item(
+                                item_type, type_display, display_name
+                            )
+                            item.set_icon_from_path(item_info["icon_path"])
 
-            # disable thumbnail creation since we get it for free
-            item.thumbnail_enabled = False
+                            # if the supplied path is an image, use the path as # the thumbnail.
+                            item.set_thumbnail_from_path(render_path)
 
-            # all we know about the file is its path. set the path in its
-            # properties for the plugins to use for processing.
-            item.properties["path"] = publish_path
+                            # disable thumbnail creation since we get it for free
+                            item.thumbnail_enabled = False
 
-            # include an indicator that this is an image sequence and the known
-            # file that belongs to this sequence
-            item.properties["sequence_paths"] = rendered_files
+                            item.properties["path"] = render_path
+                            item.properties["sequence_paths"] = sequence_files
+                            item.properties["publish_name"] = publish_name
+                            item.properties["publish_version"] = version_number
+                            item.properties[
+                                "publish_template"
+                            ] = sg_writenode_app.get_node_publish_template(
+                                node
+                            )
+                            item.properties[
+                                "work_template"
+                            ] = sg_writenode_app.get_node_render_template(node)
+                            item.properties[
+                                "colorspace"
+                            ] = sg_writenode_app.get_colorspace(node)
+                            item.properties["first_frame"] = first_frame
+                            item.properties["last_frame"] = last_frame
+                            item.properties["sg_writenode"] = node
 
-            # store publish info on the item so that the base publish plugin
-            # doesn't fall back to zero config path parsing
-            item.properties["publish_name"] = publish_name
-            item.properties["publish_version"] = version_number
-            item.properties["publish_template"] = (
-                sg_writenode_app.get_node_publish_template(node)
-            )
-            item.properties["work_template"] = (
-                sg_writenode_app.get_node_render_template(node)
-            )
-            item.properties["color_space"] = self._get_node_colorspace(node)
-            item.properties["first_frame"] = first_frame
-            item.properties["last_frame"] = last_frame
+                            # we have a publish template so disable context change. This
+                            # is a temporary measure until the publisher handles context
+                            # switching natively.
+                            item.context_change_allowed = False
 
-            # store the nuke writenode on the item as well. this can be used by
-            # secondary publish plugins
-            item.properties["sg_writenode"] = node
-
-            # we have a publish template so disable context change. This
-            # is a temporary measure until the publisher handles context
-            # switching natively.
-            item.context_change_allowed = False
-
-            self.logger.info("Collected file: %s" % (publish_path,))
+                            self.logger.info(
+                                "Collected file: %s" % (render_path,)
+                            )
 
     def _get_node_colorspace(self, node):
         """

--- a/hooks/tk-multi-publish2/basic/nuke_publish_script.py
+++ b/hooks/tk-multi-publish2/basic/nuke_publish_script.py
@@ -37,16 +37,16 @@ class NukeSessionPublishPlugin(HookBaseClass):
         contain simple html for formatting.
         """
 
-        loader_url = "https://help.autodesk.com/view/SGDEV/ENU/?contextId=PC_APP_LOADER"
+        loader_url = "https://developer.shotgridsoftware.com/a4c0a4f1/?title=Loader"
 
         return """
-        Publishes the file to Flow Production Tracking. A <b>Publish</b> entry
-        will be created in Flow Production Tracking which will include a reference
-        to the file's current path on disk. If a publish template is configured, a
-        copy of the current session will be copied to the publish template path
-        which will be the file that is published. Other users will be able to
-        access the published file via the <b><a href='%s'>Loader</a></b> so long
-        as they have access to the file's location on disk.
+        Publishes the file to ShotGrid. A <b>Publish</b> entry will be
+        created in ShotGrid which will include a reference to the file's current
+        path on disk. If a publish template is configured, a copy of the
+        current session will be copied to the publish template path which
+        will be the file that is published. Other users will be able to access
+        the published file via the <b><a href='%s'>Loader</a></b> so long as
+        they have access to the file's location on disk.
 
         If the session has not been saved, validation will fail and a button
         will be provided in the logging output to save the file.
@@ -56,8 +56,7 @@ class NukeSessionPublishPlugin(HookBaseClass):
         file to the next version after publishing.
 
         The <code>version</code> field of the resulting <b>Publish</b> in
-        Flow Production Tracking will also reflect the version number identified
-        in the filename.
+        ShotGrid will also reflect the version number identified in the filename.
         The basic worklfow recognizes the following version formats by default:
 
         <ul>
@@ -84,7 +83,9 @@ class NukeSessionPublishPlugin(HookBaseClass):
         however only the most recent publish will be available to other users.
         Warnings will be provided during validation if there are previous
         publishes.
-        """ % (loader_url,)
+        """ % (
+            loader_url,
+        )
 
     @property
     def settings(self):

--- a/hooks/tk-multi-publish2/basic/nukestudio_publish_project.py
+++ b/hooks/tk-multi-publish2/basic/nukestudio_publish_project.py
@@ -37,13 +37,13 @@ class NukeStudioProjectPublishPlugin(HookBaseClass):
         contain simple html for formatting.
         """
 
-        loader_url = "https://help.autodesk.com/view/SGDEV/ENU/?contextId=PC_APP_LOADER"
+        loader_url = "https://developer.shotgridsoftware.com/a4c0a4f1/?title=Loader"
 
         return """
-        Publishes the file to Flow Production Tracking. A <b>Publish</b> entry
-        will be created in Flow Production Tracking which will include a reference
-        to the file's current path on disk. If a publish template is configured, a
-        copy of the current session will be copied to the publish template path which
+        Publishes the file to ShotGrid. A <b>Publish</b> entry will be
+        created in ShotGrid which will include a reference to the file's current
+        path on disk. If a publish template is configured, a copy of the
+        current session will be copied to the publish template path which
         will be the file that is published. Other users will be able to access
         the published file via the <b><a href='%s'>Loader</a></b> so long as
         they have access to the file's location on disk.
@@ -56,9 +56,8 @@ class NukeStudioProjectPublishPlugin(HookBaseClass):
         file to the next version after publishing.
 
         The <code>version</code> field of the resulting <b>Publish</b> in
-        Flow Production Tracking will also reflect the version number identified
-        in the filename. The basic worklfow recognizes the following version formats
-        by default:
+        ShotGrid will also reflect the version number identified in the filename.
+        The basic worklfow recognizes the following version formats by default:
 
         <ul>
         <li><code>filename.v###.ext</code></li>
@@ -84,7 +83,9 @@ class NukeStudioProjectPublishPlugin(HookBaseClass):
         however only the most recent publish will be available to other users.
         Warnings will be provided during validation if there are previous
         publishes.
-        """ % (loader_url,)
+        """ % (
+            loader_url,
+        )
         # TODO: add link to workflow docs
 
     @property

--- a/hooks/tk-multi-publish2/basic/submit_for_review.py
+++ b/hooks/tk-multi-publish2/basic/submit_for_review.py
@@ -28,14 +28,16 @@ class NukeSubmitForReviewPlugin(HookBaseClass):
         """
 
         # look for icon one level up from this hook's folder in "icons" folder
-        return os.path.join(self.disk_location, os.pardir, "icons", "review.png")
+        return os.path.join(
+            self.disk_location, os.pardir, "icons", "review.png"
+        )
 
     @property
     def name(self):
         """
         One line display name describing the plugin
         """
-        return "Submit for Review"
+        return "Submit for Review on Deadline"
 
     @property
     def description(self):
@@ -47,11 +49,13 @@ class NukeSubmitForReviewPlugin(HookBaseClass):
         review_url = "https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Supervisor_Artist_sa_review_approval_sa_review_workflow_html"
 
         return """<p>
-        Submits a movie file to Flow Production Tracking for review. An entry will be
-        created in Flow Production Tracking which will include a reference to the movie file's
-        current path on disk. Other users will be able to access the file via
-        the <b><a href='%s'>review app</a></b> on the Flow Production Tracking website.</p>
-        """ % (review_url)
+        Submits a movie file to ShotGrid for review. An entry will be
+        created in ShotGrid which will include a reference to the movie file's current
+        path on disk. Other users will be able to access the file via
+        the <b><a href='%s'>review app</a></b> on the ShotGrid website.</p>
+        """ % (
+            review_url
+        )
 
     @property
     def settings(self):
@@ -120,37 +124,37 @@ class NukeSubmitForReviewPlugin(HookBaseClass):
         """
 
         accepted = True
-        review_submission_app = self.parent.engine.apps.get("tk-multi-reviewsubmission")
+        review_submission_app = self.parent.engine.apps.get(
+            "tk-multi-deadlinereviewsubmission"
+        )
         if review_submission_app is None:
             accepted = False
             self.logger.debug(
                 "Review submission app is not available. skipping item: %s"
                 % (item.properties["publish_name"],)
             )
-        if item.properties.get("color_space") is None:
-            accepted = False
-            self.logger.debug(
-                "'color_space' property is not defined on the item. "
-                "Item will be skipped: %s." % (item.properties["publish_name"],)
-            )
         if item.properties.get("first_frame") is None:
             accepted = False
             self.logger.debug(
                 "'first_frame' property is not defined on the item. "
-                "Item will be skipped: %s." % (item.properties["publish_name"],)
+                "Item will be skipped: %s."
+                % (item.properties["publish_name"],)
             )
         if item.properties.get("last_frame") is None:
             accepted = False
             self.logger.debug(
                 "'last_frame' property is not defined on the item. "
-                "Item will be skipped: %s." % (item.properties["publish_name"],)
+                "Item will be skipped: %s."
+                % (item.properties["publish_name"],)
             )
         path = item.properties.get("path")
+
         if path is None:
             accepted = False
             self.logger.debug(
                 "'path' property is not defined on the item. "
-                "Item will be skipped: %s." % (item.properties["publish_name"],)
+                "Item will be skipped: %s."
+                % (item.properties["publish_name"],)
             )
 
         if accepted:
@@ -159,7 +163,24 @@ class NukeSubmitForReviewPlugin(HookBaseClass):
                 "Submit for review plugin accepted: %s" % (path,),
                 extra={"action_show_folder": {"path": path}},
             )
-        return {"accepted": accepted, "checked": True}
+
+        # Determine if item should be checked or not
+        output_template = item.properties.get("work_template")
+        output_fields = output_template.get_fields(path)
+
+        render_name = output_fields.get("output")
+
+        checked_filenames = ("main",)
+
+        if render_name in checked_filenames:
+            checked = True
+            accepted = True
+
+        else:
+            checked = False
+            accepted = False
+
+        return {"accepted": accepted, "checked": checked}
 
     def validate(self, settings, item):
         """
@@ -204,17 +225,18 @@ class NukeSubmitForReviewPlugin(HookBaseClass):
         render_path = item.properties.get("path")
 
         sg_publish_data = item.properties.get("sg_publish_data")
+        print(sg_publish_data)
         if sg_publish_data is None:
             raise Exception(
                 "'sg_publish_data' was not found in the item's properties. "
                 "Review Submission for '%s' failed. This property must "
-                "be set by a publish plugin that has run before this one." % render_path
+                "be set by a publish plugin that has run before this one."
+                % render_path
             )
-        sg_task = self.parent.context.task
-        comment = item.description
-        thumbnail_path = item.get_thumbnail_as_path()
-        progress_cb = lambda *args, **kwargs: None
-        review_submission_app = self.parent.engine.apps.get("tk-multi-reviewsubmission")
+
+        tk_multi_deadlinereviewsubmission = self.parent.engine.apps.get(
+            "tk-multi-deadlinereviewsubmission"
+        )
 
         render_template = item.properties.get("work_template")
         if render_template is None:
@@ -226,7 +248,7 @@ class NukeSubmitForReviewPlugin(HookBaseClass):
         if publish_template is None:
             raise Exception(
                 "'publish_template' property not found on item. "
-                "Review submission for '%' failed." % render_path
+                "Review submission for '%s' failed." % render_path
             )
         if not render_template.validate(render_path):
             raise Exception(
@@ -235,29 +257,30 @@ class NukeSubmitForReviewPlugin(HookBaseClass):
             )
 
         render_path_fields = render_template.get_fields(render_path)
+
         first_frame = item.properties.get("first_frame")
         last_frame = item.properties.get("last_frame")
-        colorspace = item.properties.get("color_space")
+        fps = nuke.root().fps()
 
-        version = review_submission_app.render_and_submit_version(
-            publish_template,
-            render_path_fields,
-            first_frame,
-            last_frame,
-            [sg_publish_data],
-            sg_task,
-            comment,
-            thumbnail_path,
-            progress_cb,
-            colorspace,
+        colorspace = item.properties.get("colorspace")
+
+        version = tk_multi_deadlinereviewsubmission.submit_version(
+            template=publish_template,
+            fields=render_path_fields,
+            publish=sg_publish_data,
+            first_frame=first_frame,
+            last_frame=last_frame,
+            fps=fps,
+            colorspace_idt=colorspace,
         )
+
         if version:
             self.logger.info(
                 "Version uploaded for file: %s" % (render_path,),
                 extra={
                     "action_show_in_shotgun": {
                         "label": "Show Version",
-                        "tooltip": "Reveal the version in Flow Production Tracking.",
+                        "tooltip": "Reveal the version in ShotGrid.",
                         "entity": version,
                     }
                 },

--- a/python/tk_nuke/menu_generation.py
+++ b/python/tk_nuke/menu_generation.py
@@ -40,18 +40,10 @@ class BaseMenuGenerator(object):
 
         engine_root_dir = self.engine.disk_location
         self._shotgun_logo = os.path.abspath(
-            os.path.join(
-                engine_root_dir,
-                "resources",
-                "sg_logo_80px.png",
-            ),
+            os.path.join(engine_root_dir, "resources", "filmacademy_sg_logo_80px.png",),
         )
         self._shotgun_logo_blue = os.path.abspath(
-            os.path.join(
-                engine_root_dir,
-                "resources",
-                "sg_logo_blue_32px.png",
-            ),
+            os.path.join(engine_root_dir, "resources", "filmacademy_logo_32px.png",),
         )
 
     @property
@@ -190,7 +182,8 @@ class HieroMenuGenerator(BaseMenuGenerator):
 
         from sgtk.platform.qt import QtGui
 
-        self._menu_handle = QtGui.QMenu("Flow Production Tracking")
+        # Adding menu name
+        self._menu_handle = QtGui.QMenu(self._menu_name)
         help = hiero.ui.findMenuAction("Cache")
         menuBar = hiero.ui.menuBar()
         menuBar.insertMenu(help, self._menu_handle)
@@ -592,13 +585,22 @@ class NukeMenuGenerator(BaseMenuGenerator):
             if cmd.type == "node":
                 # Get icon if specified - default to sgtk icon if not specified.
                 icon = cmd.properties.get("icon", self._shotgun_logo)
+
+                # Get hotkey if specified
+                hotkey = cmd.properties.get("hotkey")
+
+                # Fix for Windows slashes
+                icon = icon.replace(os.sep, '/')
                 command_context = cmd.properties.get("context")
 
                 # If the app recorded a context that it wants the command to be associated
                 # with, we need to check it against the current engine context. If they
                 # don't match then we don't add it.
                 if command_context is None or command_context is self.engine.context:
-                    node_menu_handle.addCommand(cmd.name, cmd.callback, icon=icon)
+                    if hotkey:
+                        node_menu_handle.addCommand(cmd.name, cmd.callback, hotkey, icon=icon)
+                    else:
+                        node_menu_handle.addCommand(cmd.name, cmd.callback, icon=icon)
             elif cmd.type == "context_menu":
                 cmd.add_command_to_menu(self._context_menu)
             else:


### PR DESCRIPTION
-collect_sg_writenodes func in collector.py has been reverted. maybe look in to this later when updating tk-multi-publish2

-same goes for tk-multi-deadlinereviewsubmission which has been kept instead of tk-multi-reviewsubmission submit_for_review.py

-overwritten flows oldest version to make some of our current school projects compatible